### PR TITLE
errorHandler behavior change based on NODE_ENV

### DIFF
--- a/server/util/errorHandler.js
+++ b/server/util/errorHandler.js
@@ -1,10 +1,22 @@
+require("dotenv").config();
+
 const errorHandler = async (err, req, res, next) => {
-  console.log(err);
+  const environment = process.env.NODE_ENV || "development";
   res.status(err.status || 500);
+
+  if (environment === "development") {
+    console.log(err);
+    return res.send({
+      error: {
+        status: err.status || 500,
+        message: err.message,
+      },
+    });
+  }
+
   res.send({
     error: {
       status: err.status || 500,
-      message: err.message,
     },
   });
 };


### PR DESCRIPTION
Server error handler now has two modes:

When NODE_ENV=
1. "production": errors are not console.logged on server and only the error status code is sent to client
2. "development" or undefined: errors are console.logged on server and response contains error status code and an error message.

I added this because some errors were leaking information about the function names. Ideally, there would be none of these types of errors to leak (only errors that I have created intentionally using http-errors), but for now I believe this is the safest way to deal with this issue.