### PR TITLE
Feature server http cookie

### DIFF
--- a/server/authServer.js
+++ b/server/authServer.js
@@ -3,6 +3,7 @@ const express = require("express");
 const redisClient = require("./util/redis");
 const morgan = require("morgan");
 const corsMiddleware = require("./util/corsMiddleware");
+const cookieParser = require("cookie-parser");
 
 const app = express();
 const PORT = process.env.AUTH_PORT || 4001;
@@ -14,6 +15,7 @@ redisClient.connect();
 // middleware
 app.use(express.json());
 app.use(morgan("tiny"));
+app.use(cookieParser());
 app.use(corsMiddleware);
 app.use((req, res, next) => {
   req.redisClient = redisClient;

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -47,7 +47,12 @@ const loginUserController = async (req, res, next) => {
 
     res
       .status(200)
-      .json({ accessToken: accessToken, refreshToken: refreshToken });
+      .cookie("refreshToken", refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "strict",
+      })
+      .json({ accessToken: accessToken });
   } catch (error) {
     next(error);
   }
@@ -82,7 +87,12 @@ const refreshTokenController = async (req, res, next) => {
 
     res
       .status(200)
-      .json({ accessToken: accessToken, refreshToken: refreshToken });
+      .cookie("refreshToken", refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "strict",
+      })
+      .json({ accessToken: accessToken });
   } catch (error) {
     console.error("Error:", error);
     res.status(500).json({

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "http-errors": "^2.0.0",
@@ -460,6 +461,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "http-errors": "^2.0.0",

--- a/server/util/auth.js
+++ b/server/util/auth.js
@@ -40,7 +40,8 @@ async function verifyRefreshToken(req, res, next) {
   const redisClient = req.redisClient;
 
   // validate req body
-  const { refreshToken } = req.body;
+  const refreshToken = req.cookies["refreshToken"];
+  console.log(refreshToken);
   if (!refreshToken) return res.sendStatus(400);
 
   // verify token


### PR DESCRIPTION
The branch changes the backend server behavior such that the refreshToken will always be sent and received as a secure httpOnly cookie. This prevents the token from being accessed by the client js and keeps the project more secure.